### PR TITLE
Document speedscope global installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ gem "singed"
 
 Then run `bundle install`
 
+Then run `npm install -g speedscope`
+
 ## Usage
 
 Simplest is calling with a block:


### PR DESCRIPTION
Speedscope must be installed globally for the graph to be displayed.