### PR TITLE
Fix rspec check

### DIFF
--- a/lib/singed.rb
+++ b/lib/singed.rb
@@ -53,4 +53,4 @@ end
 
 require 'singed/kernel_ext'
 require 'singed/railtie' if defined?(Rails::Railtie)
-require 'singed/rspec' if defined?(RSpec)
+require 'singed/rspec' if defined?(RSpec) && RSpec.respond_to?(:configure)


### PR DESCRIPTION
If you use rspec-rails, it's possible for `RSpec` to be defined, but not for RSpec.configure to be available yet. This explicitly checks for that method.

We already recommend requiring `singed/rspec` in the spec helper from the README.md, so I think this should be enough to close https://github.com/rubyatscale/singed/issues/3