### PR TITLE
Adds Github Actions CI for different Ruby versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: CI Test
+on: [ push ]
+jobs:
+  build:
+    name: Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: 3.2
+            bundler_version: 2.4.4
+          - ruby: 3.1
+            bundler_version: 2.4.4
+          - ruby: 3.0
+            bundler_version: 2.4.4
+    env:
+      CI: 1
+      BUNDLER_VERSION: ${{ matrix.bundler_version }}
+      USE_OFFICIAL_GEM_SOURCE: 1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install bundler
+        run: gem install bundler -v $BUNDLER_VERSION
+      - name: Install dependencies
+        run: bundle install
+      - run: bundle exec rspec


### PR DESCRIPTION
👋  Thanks for the review in advance.

This PR adds CI support for the Ruby versions that are currently maintained. 
Here is a screenshot of the CI passing in a draft PR https://github.com/berkos/singed/pull/1
<img width="928" alt="Screenshot 2023-05-14 at 21 24 25" src="https://github.com/rubyatscale/singed/assets/1176797/b8e30b04-70ef-41dd-959e-c399570b5a0d">

To enable CI in https://github.com/rubyatscale/singed you'll need to enable Actions https://github.com/rubyatscale/singed/actions

Thank you 