### PR TITLE
Use rspec hook filters to target flamegraph logic

### DIFF
--- a/lib/singed/rspec.rb
+++ b/lib/singed/rspec.rb
@@ -1,11 +1,7 @@
 require 'singed'
 
 RSpec.configure do |config|
-  config.around do |example|
-    if example.metadata[:flamegraph]
-      flamegraph { example.run }
-    else
-      example.run
-    end
+  config.around(flamegraph: true) do |example|
+    flamegraph { example.run }
   end
 end


### PR DESCRIPTION
The current RSpec hook always run and decides whether or not to flamegraph _inside_ the hook. That means it'll always show up on backtraces and does work. This change makes it so that it only runs when the metadata is set.