### PR TITLE
Include first 6 digits of micro seconds

### DIFF
--- a/lib/singed/flamegraph.rb
+++ b/lib/singed/flamegraph.rb
@@ -53,7 +53,7 @@ module Singed
     end
 
     def self.generate_filename(label: nil, time: Time.now) # rubocop:disable Rails/TimeZone
-      formatted_time = time.strftime('%Y%m%d%H%M%S')
+      formatted_time = time.strftime('%Y%m%d%H%M%S-%6N')
       basename_parts = ['speedscope', label, formatted_time].compact
 
       file = Singed.output_directory.join("#{basename_parts.join('-')}.json")


### PR DESCRIPTION
When doing a lot of requests at the same time (ajax / graphql etc) we saw constant filename clashes. This adds some microseconds to the filename to avoid this.

I… didn't find any tests for this so erm, no tests added sorry 😬 