### PR TITLE
FIX: Memoize Singed.output_directory to prevent path override

### DIFF
--- a/lib/singed/railtie.rb
+++ b/lib/singed/railtie.rb
@@ -14,7 +14,7 @@ module Singed
     end
 
     def self.init!
-      Singed.output_directory = Rails.root.join("tmp/speedscope")
+      Singed.output_directory ||= Rails.root.join("tmp/speedscope")
       Singed.backtrace_cleaner = Rails.backtrace_cleaner
     end
   end


### PR DESCRIPTION
### Problem
After setting `Singed.output_directory = "flamegraphs/"` inside development.rb the gem initialisation defaults it back to "tmp/speedscope"

### Solution
Added memoization using the `||=` operator to cache the computed path after its first calculation. This ensures that:
- The path is only computed once during Rails initialization
- The original fallback behavior is preserved if a custom path is set before initialization

### Impact
- Reduces unnecessary path computations
- Maintains compatibility with existing custom path configurations
- No breaking changes to the public API

### Testing
- [ ] Verified that the output directory is correctly set on initialization
- [x] Confirmed that custom paths set before initialization are not overwritten

Resulting stacktrace from server after change with bundle open
![image](https://github.com/user-attachments/assets/5eb79517-d250-4787-b67f-07197aa7bdd8)

Before hand:
![image](https://github.com/user-attachments/assets/595c9eb2-7810-4cfc-8102-6484611804ef)

development.rb setup
![image](https://github.com/user-attachments/assets/715a4a2f-259e-49ab-ba12-173110505d40)
