### PR TITLE
Global spec temp directory setup

### DIFF
--- a/spec/singed_spec.rb
+++ b/spec/singed_spec.rb
@@ -1,19 +1,12 @@
 # frozen_string_literal: true
 
-require "tempfile"
-
 RSpec.describe Singed do
   around do |example|
-    original_output_directory = Singed.output_directory
-    Singed.output_directory = Dir.mktmpdir("singed-spec")
     original_enabled = Singed.enabled?
-    begin
-      example.run
-    ensure
-      Singed.output_directory = original_output_directory
-      Singed.enabled = original_enabled
-      Singed.instance_variable_set(:@current_flamegraph, nil)
-    end
+    example.run
+  ensure
+    Singed.enabled = original_enabled
+    Singed.instance_variable_set(:@current_flamegraph, nil)
   end
 
   describe ".start" do
@@ -42,7 +35,6 @@ RSpec.describe Singed do
   describe ".stop" do
     before do
       Singed.enabled = true
-      Singed.output_directory = Dir.mktmpdir("singed-spec")
     end
 
     it "returns nil when not profiling" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,12 +19,13 @@ require "tmpdir"
 
 RSpec.configure do |config|
   config.around do |example|
+    original_output_directory = Singed.output_directory
     Dir.mktmpdir("singed-spec") do |dir|
       Singed.output_directory = dir
       example.run
     end
   ensure
-    Singed.output_directory = nil
+    Singed.output_directory = original_output_directory
   end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,17 @@
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require "singed"
+require "tmpdir"
 
 RSpec.configure do |config|
+  config.around do |example|
+    Dir.mktmpdir("singed-spec") do |dir|
+      Singed.output_directory = dir
+      example.run
+    end
+  ensure
+    Singed.output_directory = nil
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,5 +1,4 @@
 require "singed/sidekiq"
-require "tempfile"
 
 RSpec.configure do |config|
   config.before(:suite) do
@@ -15,14 +14,6 @@ RSpec.configure do |config|
 
     ActiveJob::Base.queue_adapter = :sidekiq
     ActiveJob::Base.logger = Logger.new(nil)
-  end
-
-  config.around(:each, sidekiq: true) do |example|
-    orig_dir = Singed.output_directory
-    Singed.output_directory = Dir.mktmpdir("singed-sidekiq-spec")
-    example.run
-  ensure
-    Singed.output_directory = orig_dir
   end
 end
 


### PR DESCRIPTION
## Summary
- Move temp directory setup/cleanup to `spec_helper.rb` using `Dir.mktmpdir` block form
- Automatically cleans up temp directories after each spec (no leaks)
- Removes duplicate setup from `singed_spec.rb` and `spec/support/sidekiq.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)