### PR TITLE
Require Ruby >= 3.3 and update CI Ruby versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.2
           - 3.3
           - 3.4
           - 4.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
 
 require:
   - standard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,4 +126,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.6.9
+   4.0.15

--- a/singed.gemspec
+++ b/singed.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Josh Nichols"]
   spec.email = ["josh.nichols@gusto.com"]
   spec.summary = "Quick and easy way to get flamegraphs from a specific part of your code base"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3"
   spec.homepage = "https://github.com/rubyatscale/singed"
   spec.metadata = {
     "source_code_uri" => "https://github.com/rubyatscale/singed",


### PR DESCRIPTION
## Summary

Raises the minimum supported Ruby version to 3.3 (Ruby 3.2 is now EOL) and refreshes CI accordingly.

Changes:
- **`singed.gemspec`**: `required_ruby_version` bumped from `>= 3.2.0` to `>= 3.3`.
- **`.github/workflows/build.yml`**: dropped Ruby `3.2` from the CI test matrix; the matrix now runs `3.3`, `3.4`, and `4.0`.
- **`.rubocop.yml`**: `AllCops.TargetRubyVersion` bumped from `3.2` to `3.3`.

No `.ruby-version` / `.tool-versions` files exist, and `.standard.yml` has no `TargetRubyVersion`, so no changes were needed there. The README contains no explicit minimum-Ruby statement to update.

## Motivation

Resolves the Ruby version restrictions from rubyatscale/pack_stats#56, where supporting EOL Ruby forced older/vulnerable transitive dependencies. Dropping EOL Ruby 3.2 allows the supported set (3.3 and 3.4) to track current, non-vulnerable dependencies.



## Bundler

Also bumps `BUNDLED WITH` in `Gemfile.lock` to bundler **4.0.15** (latest). The previously pinned bundler version crashes on Ruby `head` (`NameError: uninitialized constant Pathname::SEPARATOR_PAT`) — see [this failing run](https://github.com/rubyatscale/code_manifest/actions/runs/28200903631/job/83539858239?pr=12). Pinning the current bundler resolves it.