### PR TITLE
Add explicit GITHUB_TOKEN permissions to CI Test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: CI Test
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
CodeQL actions/missing-workflow-permissions (alert #3) flagged the
`build` job in .github/workflows/build.yml, which had no effective
permissions block and so inherited the repository default.

The job only checks out the repo, installs Ruby and the bundle, and runs
rspec — it writes nothing back to GitHub — so a workflow-level
`contents: read` is the least privilege that keeps it working. Placed at
the workflow level (matching push_gem.yml in this repo) since build.yml
has a single job.

push_gem.yml and standardrb.yaml already declare permissions and are not
flagged; left untouched.


### Alerts resolved

- [#3](https://github.com/rubyatscale/singed/security/code-scanning/3) `actions/missing-workflow-permissions` (medium) — `.github/workflows/build.yml:5`

### Verification

- Every job in every flagged workflow now has an effective `permissions:` block (cross-checked by parsing the YAML against the alert list).
- `actionlint` output is byte-identical to `main` — no new findings introduced.
- `codeql.yml` untouched.
